### PR TITLE
Automatic spool mapping

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app",
-  "version": "1.3.6",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "1.3.6",
+      "version": "1.5.0",
       "dependencies": {
         "@prisma/adapter-better-sqlite3": "^7.2.0",
         "@prisma/client": "^7.3.0",
@@ -92,6 +92,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -343,7 +344,8 @@
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.15.tgz",
       "integrity": "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==",
       "devOptional": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.0.20",
@@ -2840,6 +2842,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2850,6 +2853,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2915,6 +2919,7 @@
       "integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.51.0",
         "@typescript-eslint/types": "8.51.0",
@@ -3414,6 +3419,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3830,6 +3836,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4794,6 +4801,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4979,6 +4987,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5801,6 +5810,7 @@
       "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7599,6 +7609,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "7.3.0",
         "@prisma/dev": "0.20.0",
@@ -7764,6 +7775,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7773,6 +7785,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7784,13 +7797,15 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -7940,7 +7955,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -8839,6 +8855,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9023,6 +9040,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9431,6 +9449,7 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/app/prisma/migrations/20260416141007_add_filament_mapping/migration.sql
+++ b/app/prisma/migrations/20260416141007_add_filament_mapping/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "FilamentMapping" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "material" TEXT NOT NULL,
+    "color" TEXT NOT NULL,
+    "spoolId" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FilamentMapping_name_material_color_key" ON "FilamentMapping"("name", "material", "color");

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -49,6 +49,20 @@ model Automation {
   updatedAt      DateTime @updatedAt
 }
 
+// Filament mapping: name+material+color -> spoolId
+// Enables auto-assignment for spools without RFID/QR tags
+model FilamentMapping {
+  id        String   @id @default(cuid())
+  name      String   // Filament name from printer (normalized: lowercase trimmed)
+  material  String   // Material type (normalized: uppercase trimmed)
+  color     String   // Hex color including alpha channel (normalized: lowercase, no #)
+  spoolId   Int      // Spoolman spool ID
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([name, material, color])
+}
+
 // Activity log for debugging/monitoring
 model ActivityLog {
   id        String   @id @default(cuid())

--- a/app/src/app/api/mappings/route.ts
+++ b/app/src/app/api/mappings/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@/lib/db';
+import { SpoolmanClient } from '@/lib/api/spoolman';
+
+/**
+ * Normalize filament mapping fields for storage and lookup.
+ * - name: trimmed (preserves casing from the printer / webhook)
+ * - material: trimmed (preserves casing)
+ * - color: trimmed, '#' stripped, lowercased (hex; alpha channel preserved)
+ */
+export function normalizeMappingFields(name: string, material: string, color: string) {
+  return {
+    name: name.trim(),
+    material: material.trim(),
+    color: color.trim().replace('#', '').toLowerCase(),
+  };
+}
+
+/**
+ * When the printer reports no spool loaded, HA often sets name or material to "Empty".
+ * Filament mappings must not be created for this state.
+ */
+export function isEmptyTrayFilamentReport(name: string, material: string): boolean {
+  return name.trim().toLowerCase() === 'empty' || material.trim().toLowerCase() === 'empty';
+}
+
+export async function GET() {
+  try {
+    const mappings = await prisma.filamentMapping.findMany({
+      orderBy: { updatedAt: 'desc' },
+    });
+
+    const spoolmanConnection = await prisma.spoolmanConnection.findFirst();
+    let spoolMap = new Map<number, { name: string; material: string; color_hex: string; vendor: string; archived: boolean }>();
+
+    if (spoolmanConnection) {
+      try {
+        const client = new SpoolmanClient(spoolmanConnection.url);
+        const spools = await client.getSpools(true);
+        for (const spool of spools) {
+          spoolMap.set(spool.id, {
+            name: spool.filament?.name || '',
+            material: spool.filament?.material || '',
+            color_hex: spool.filament?.color_hex || '',
+            vendor: spool.filament?.vendor?.name || '',
+            archived: spool.archived,
+          });
+        }
+      } catch {
+        // Spoolman unavailable — return mappings without spool details
+      }
+    }
+
+    const enriched = mappings.map((m) => ({
+      ...m,
+      spool: spoolMap.get(m.spoolId) || null,
+    }));
+
+    return NextResponse.json({ mappings: enriched });
+  } catch (error) {
+    console.error('Error fetching mappings:', error);
+    return NextResponse.json({ error: 'Failed to fetch mappings' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { name, material, color, spoolId } = body;
+
+    if (!name || !material || !color || !spoolId) {
+      return NextResponse.json(
+        { error: 'Missing required fields: name, material, color, spoolId' },
+        { status: 400 },
+      );
+    }
+
+    if (isEmptyTrayFilamentReport(String(name), String(material))) {
+      return NextResponse.json(
+        { error: 'Cannot create a mapping when name or material is Empty (no spool loaded)' },
+        { status: 400 },
+      );
+    }
+
+    const normalized = normalizeMappingFields(name, material, color);
+
+    const mapping = await prisma.filamentMapping.upsert({
+      where: {
+        name_material_color: {
+          name: normalized.name,
+          material: normalized.material,
+          color: normalized.color,
+        },
+      },
+      update: { spoolId: Number(spoolId) },
+      create: {
+        name: normalized.name,
+        material: normalized.material,
+        color: normalized.color,
+        spoolId: Number(spoolId),
+      },
+    });
+
+    return NextResponse.json({ mapping });
+  } catch (error) {
+    console.error('Error creating/updating mapping:', error);
+    return NextResponse.json({ error: 'Failed to save mapping' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { id } = body;
+
+    if (!id) {
+      return NextResponse.json({ error: 'Missing required field: id' }, { status: 400 });
+    }
+
+    await prisma.filamentMapping.delete({ where: { id } });
+
+    return NextResponse.json({ status: 'deleted' });
+  } catch (error) {
+    console.error('Error deleting mapping:', error);
+    return NextResponse.json({ error: 'Failed to delete mapping' }, { status: 500 });
+  }
+}

--- a/app/src/app/api/settings/route.ts
+++ b/app/src/app/api/settings/route.ts
@@ -48,6 +48,8 @@ export async function GET() {
       // Fetch optional settings
       const qrBaseUrlSetting = await prisma.settings.findUnique({ where: { key: 'qr_base_url' } });
       const showLocationSetting = await prisma.settings.findUnique({ where: { key: 'show_spool_location' } });
+      const autoMappingSetting = await prisma.settings.findUnique({ where: { key: 'auto_mapping_enabled' } });
+      const printerFilamentReportSetting = await prisma.settings.findUnique({ where: { key: 'show_printer_filament_report' } });
 
       return NextResponse.json({
         embeddedMode: false,
@@ -63,6 +65,8 @@ export async function GET() {
         } : null,
         qrBaseUrl: qrBaseUrlSetting?.value || '',
         showSpoolLocation: showLocationSetting?.value === 'true',
+        showPrinterFilamentReport: printerFilamentReportSetting?.value === 'true',
+        autoMappingEnabled: !autoMappingSetting || autoMappingSetting.value === 'true',
       });
     }
 
@@ -243,6 +247,8 @@ export async function GET() {
     // Fetch optional settings
     const qrBaseUrlSetting = await prisma.settings.findUnique({ where: { key: 'qr_base_url' } });
     const showLocationSetting = await prisma.settings.findUnique({ where: { key: 'show_spool_location' } });
+    const autoMappingSetting = await prisma.settings.findUnique({ where: { key: 'auto_mapping_enabled' } });
+    const printerFilamentReportSetting = await prisma.settings.findUnique({ where: { key: 'show_printer_filament_report' } });
 
     return NextResponse.json({
       embeddedMode,
@@ -254,6 +260,8 @@ export async function GET() {
       } : null,
       qrBaseUrl: qrBaseUrlSetting?.value || '',
       showSpoolLocation: showLocationSetting?.value === 'true',
+      showPrinterFilamentReport: printerFilamentReportSetting?.value === 'true',
+      autoMappingEnabled: !autoMappingSetting || autoMappingSetting.value === 'true',
     });
   } catch (error) {
     console.error('Error fetching settings:', error);
@@ -332,6 +340,26 @@ export async function POST(request: NextRequest) {
       await prisma.settings.upsert({
         where: { key: 'show_spool_location' },
         create: { key: 'show_spool_location', value: String(enabled) },
+        update: { value: String(enabled) },
+      });
+      return NextResponse.json({ success: true });
+    }
+
+    if (type === 'show_printer_filament_report') {
+      const enabled = body.enabled === true;
+      await prisma.settings.upsert({
+        where: { key: 'show_printer_filament_report' },
+        create: { key: 'show_printer_filament_report', value: String(enabled) },
+        update: { value: String(enabled) },
+      });
+      return NextResponse.json({ success: true });
+    }
+
+    if (type === 'auto_mapping') {
+      const enabled = body.enabled === true;
+      await prisma.settings.upsert({
+        where: { key: 'auto_mapping_enabled' },
+        create: { key: 'auto_mapping_enabled', value: String(enabled) },
         update: { value: String(enabled) },
       });
       return NextResponse.json({ success: true });

--- a/app/src/app/api/spools/route.ts
+++ b/app/src/app/api/spools/route.ts
@@ -3,6 +3,7 @@ import prisma from '@/lib/db';
 import { SpoolmanClient } from '@/lib/api/spoolman';
 import { HomeAssistantClient } from '@/lib/api/homeassistant';
 import { createActivityLog } from '@/lib/activity-log';
+import { normalizeMappingFields, isEmptyTrayFilamentReport } from '@/app/api/mappings/route';
 
 export async function GET() {
   try {
@@ -28,7 +29,7 @@ export async function GET() {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { spoolId, trayId } = body;
+    const { spoolId, trayId, trayName, trayMaterial, trayColor } = body;
 
     const spoolmanConnection = await prisma.spoolmanConnection.findFirst();
 
@@ -60,7 +61,52 @@ export async function POST(request: NextRequest) {
       details: { spoolId, trayId },
     });
 
-    return NextResponse.json({ spool: updatedSpool });
+    // Auto-create filament mapping if enabled and spool has no RFID/serial tag
+    let mappingCreated = false;
+    if (
+      trayName &&
+      trayMaterial &&
+      trayColor &&
+      !isEmptyTrayFilamentReport(trayName, trayMaterial)
+    ) {
+      try {
+        const autoMappingSetting = await prisma.settings.findUnique({ where: { key: 'auto_mapping_enabled' } });
+        const autoMappingEnabled = !autoMappingSetting || autoMappingSetting.value === 'true';
+
+        const existingTag = updatedSpool.extra?.['tag'];
+        const hasValidTag = existingTag && (() => {
+          try {
+            const parsed = JSON.parse(existingTag);
+            return parsed && parsed !== 'unknown' && parsed !== '' && parsed.replace(/0/g, '') !== '';
+          } catch { return false; }
+        })();
+
+        if (autoMappingEnabled && !hasValidTag) {
+          const normalized = normalizeMappingFields(trayName, trayMaterial, trayColor);
+          await prisma.filamentMapping.upsert({
+            where: {
+              name_material_color: {
+                name: normalized.name,
+                material: normalized.material,
+                color: normalized.color,
+              },
+            },
+            update: { spoolId: Number(spoolId) },
+            create: {
+              name: normalized.name,
+              material: normalized.material,
+              color: normalized.color,
+              spoolId: Number(spoolId),
+            },
+          });
+          mappingCreated = true;
+        }
+      } catch (err) {
+        console.error('Failed to auto-create filament mapping:', err);
+      }
+    }
+
+    return NextResponse.json({ spool: updatedSpool, mappingCreated });
   } catch (error) {
     console.error('Error assigning spool:', error);
     return NextResponse.json({ error: 'Failed to assign spool' }, { status: 500 });

--- a/app/src/app/api/webhook/route.ts
+++ b/app/src/app/api/webhook/route.ts
@@ -5,6 +5,7 @@ import { HomeAssistantClient } from '@/lib/api/homeassistant';
 import { spoolEvents, SPOOL_UPDATED, SpoolUpdateEvent } from '@/lib/events';
 import { createActivityLog } from '@/lib/activity-log';
 import { checkAndUpdateAlerts } from '@/lib/alerts';
+import { normalizeMappingFields } from '@/app/api/mappings/route';
 
 /**
  * Webhook endpoint for Home Assistant automations
@@ -230,7 +231,7 @@ export async function POST(request: NextRequest) {
 
     // Handle tray_change event - auto-assign spool by serial number or handle empty tray
     if (event === 'tray_change') {
-      const { tray_entity_id, tray_uuid, name, material } = body;
+      const { tray_entity_id, tray_uuid, name, material, color } = body;
       const spools = await client.getSpools();
 
       // Resolve entity_id to unique_id for matching and assignment
@@ -324,9 +325,88 @@ export async function POST(request: NextRequest) {
         }
       }
 
+      // Try filament mapping lookup (name+material+color -> spoolId)
+      if (name && material && color) {
+        const normalized = normalizeMappingFields(name, material, color);
+        const mapping = await prisma.filamentMapping.findUnique({
+          where: {
+            name_material_color: {
+              name: normalized.name,
+              material: normalized.material,
+              color: normalized.color,
+            },
+          },
+        });
+
+        if (mapping) {
+          const mappedSpool = spools.find(s => s.id === mapping.spoolId && !s.archived);
+          if (mappedSpool) {
+            await client.assignSpoolToTray(mappedSpool.id, trayUniqueId);
+
+            const updateEvent: SpoolUpdateEvent = {
+              type: 'assign',
+              spoolId: mappedSpool.id,
+              spoolName: mappedSpool.filament.name,
+              trayId: tray_entity_id,
+              timestamp: Date.now(),
+            };
+            spoolEvents.emit(SPOOL_UPDATED, updateEvent);
+
+            await createActivityLog({
+              type: 'spool_change',
+              message: `Auto-assigned spool #${mappedSpool.id} to ${tray_entity_id} (matched by filament mapping)`,
+              details: { spoolId: mappedSpool.id, trayId: tray_entity_id, matchedBy: 'filament_mapping', mapping: normalized },
+            });
+
+            return NextResponse.json({
+              status: 'success',
+              spool: mappedSpool,
+              matchedBy: 'filament_mapping',
+            });
+          }
+        }
+      }
+
+      // No auto-match — clear any previous assignment so the tray is not stuck on a wrong spool
+      // (e.g. user changed filament name/type/color on the printer and no mapping matches)
+      const jsonTrayNoMatch = JSON.stringify(trayUniqueId);
+      let assignedSpoolNoMatch = spools.find(s => s.extra?.['active_tray'] === jsonTrayNoMatch);
+      if (!assignedSpoolNoMatch) {
+        const jsonEntityNoMatch = JSON.stringify(tray_entity_id);
+        assignedSpoolNoMatch = spools.find(s => s.extra?.['active_tray'] === jsonEntityNoMatch);
+      }
+
+      let unassignedSpoolId: number | undefined;
+      if (assignedSpoolNoMatch) {
+        console.log(
+          `Tray ${tray_entity_id} reports filament with no matching spool; unassigning spool #${assignedSpoolNoMatch.id}`,
+        );
+        await client.unassignSpoolFromTray(assignedSpoolNoMatch.id);
+        unassignedSpoolId = assignedSpoolNoMatch.id;
+
+        const unassignEvent: SpoolUpdateEvent = {
+          type: 'unassign',
+          spoolId: assignedSpoolNoMatch.id,
+          spoolName: assignedSpoolNoMatch.filament.name,
+          trayId: tray_entity_id,
+          timestamp: Date.now(),
+        };
+        spoolEvents.emit(SPOOL_UPDATED, unassignEvent);
+
+        await createActivityLog({
+          type: 'spool_unassign',
+          message: `Auto-unassigned spool #${assignedSpoolNoMatch.id} from ${tray_entity_id} (printer report did not match RFID, mapping, or mapped spool missing)`,
+          details: {
+            spoolId: assignedSpoolNoMatch.id,
+            trayId: tray_entity_id,
+            reason: 'tray_change_no_match',
+          },
+        });
+      }
+
       // No auto-match - user needs to manually assign spool
       // Log what the printer detected for debugging
-      console.log(`Tray ${tray_entity_id} changed but no matching spool found. Printer reports: name="${name}", material="${material}", tray_uuid="${tray_uuid}"`);
+      console.log(`Tray ${tray_entity_id} changed but no matching spool found. Printer reports: name="${name}", material="${material}", color="${color}", tray_uuid="${tray_uuid}"`);
 
       // Log to activity log so users can see all tray changes in the webapp
       await createActivityLog({
@@ -334,8 +414,9 @@ export async function POST(request: NextRequest) {
         message: `Tray change detected: ${tray_entity_id} has filament but no matching spool`,
         details: {
           trayId: tray_entity_id,
-          printerReports: { name, material, tray_uuid },
+          printerReports: { name, material, color, tray_uuid },
           action: 'manual_assignment_required',
+          previousAssignmentCleared: Boolean(unassignedSpoolId),
         },
       });
 
@@ -350,7 +431,11 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({
         status: 'no_match',
         message: 'No spool assigned to this tray. Please assign a spool manually in SpoolmanSync.',
-        printerReports: { name, material, tray_uuid },
+        printerReports: { name, material, tray_uuid, color },
+        ...(unassignedSpoolId !== undefined && {
+          unassigned: true,
+          unassignedSpoolId,
+        }),
       });
     }
 

--- a/app/src/app/mappings/page.tsx
+++ b/app/src/app/mappings/page.tsx
@@ -1,0 +1,279 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { Nav } from '@/components/nav';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { SpoolColorSwatch } from '@/components/spool-color-swatch';
+import { toast } from 'sonner';
+import type { Spool } from '@/lib/api/spoolman';
+import { buildSpoolSearchValue } from '@/lib/api/spoolman';
+
+interface MappingSpool {
+  name: string;
+  material: string;
+  color_hex: string;
+  vendor: string;
+  archived: boolean;
+}
+
+interface FilamentMapping {
+  id: string;
+  name: string;
+  material: string;
+  color: string;
+  createdAt: string;
+  updatedAt: string;
+  spool: MappingSpool | null;
+}
+
+export default function MappingsPage() {
+  const [mappings, setMappings] = useState<FilamentMapping[]>([]);
+  const [spools, setSpools] = useState<Spool[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [editingMapping, setEditingMapping] = useState<FilamentMapping | null>(null);
+  const [editDialogOpen, setEditDialogOpen] = useState(false);
+
+  const fetchMappings = useCallback(async () => {
+    try {
+      const res = await fetch('/api/mappings');
+      const data = await res.json();
+      setMappings(data.mappings || []);
+    } catch {
+      toast.error('Failed to load mappings');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const fetchSpools = useCallback(async () => {
+    try {
+      const res = await fetch('/api/spools');
+      const data = await res.json();
+      setSpools(data.spools || []);
+    } catch {
+      // Spools needed for edit dialog only
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchMappings();
+    fetchSpools();
+  }, [fetchMappings, fetchSpools]);
+
+  const handleDelete = async (id: string) => {
+    try {
+      const res = await fetch('/api/mappings', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id }),
+      });
+      if (!res.ok) throw new Error();
+      toast.success('Mapping deleted');
+      fetchMappings();
+    } catch {
+      toast.error('Failed to delete mapping');
+    }
+  };
+
+  const handleChangeSpool = async (mapping: FilamentMapping, newSpoolId: number) => {
+    try {
+      const res = await fetch('/api/mappings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: mapping.name,
+          material: mapping.material,
+          color: mapping.color,
+          spoolId: newSpoolId,
+        }),
+      });
+      if (!res.ok) throw new Error();
+      toast.success('Mapping updated');
+      setEditDialogOpen(false);
+      setEditingMapping(null);
+      fetchMappings();
+    } catch {
+      toast.error('Failed to update mapping');
+    }
+  };
+
+  const formatColor = (hex: string) => `#${hex}`;
+
+  const formatSpoolLine = (s: MappingSpool) =>
+    [s.name, s.material, s.vendor].filter((p) => p.trim() !== '').join(' / ');
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Nav />
+      <main className="w-full max-w-7xl mx-auto px-3 sm:px-4 md:px-6 py-6 space-y-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold">Filament Mappings</h1>
+            <p className="text-sm text-muted-foreground mt-1">
+              Mappings link printer-reported filament name, material, and color to a specific spool for automatic assignment without RFID
+            </p>
+          </div>
+        </div>
+
+        {loading ? (
+          <Card>
+            <CardContent className="py-8">
+              <p className="text-center text-muted-foreground">Loading mappings...</p>
+            </CardContent>
+          </Card>
+        ) : mappings.length === 0 ? (
+          <Card>
+            <CardContent className="py-12">
+              <div className="text-center space-y-3">
+                <p className="text-muted-foreground">No filament mappings yet</p>
+                <p className="text-sm text-muted-foreground">
+                  Mappings are created automatically when you assign a spool to a tray that has no RFID tag.
+                  You can enable or disable this in Settings.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="space-y-3">
+            {mappings.map((mapping) => (
+              <Card key={mapping.id}>
+                <CardContent className="py-4">
+                  <div className="flex items-center gap-4">
+                    {/* Color swatch */}
+                    <div
+                      className="h-10 w-10 rounded-full flex-shrink-0"
+                      style={{
+                        backgroundColor: formatColor(mapping.color),
+                        border: '2px solid var(--border)',
+                      }}
+                    />
+
+                    {/* Mapping info */}
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <Badge variant="secondary">{mapping.material}</Badge>
+                        <span className="text-sm font-medium truncate">{mapping.name}</span>
+                        <span className="text-xs text-muted-foreground">{formatColor(mapping.color)}</span>
+                      </div>
+
+                      {/* Spool info */}
+                      <div className="mt-1 flex items-center gap-2">
+                        <span className="text-xs text-muted-foreground">→</span>
+                        {mapping.spool ? (
+                          <span className="text-sm">
+                            {mapping.spool.archived && (
+                              <Badge variant="outline" className="mr-1 text-orange-600 border-orange-300">Archived</Badge>
+                            )}
+                            <span className="font-medium">{formatSpoolLine(mapping.spool)}</span>
+                          </span>
+                        ) : (
+                          <span className="text-sm text-muted-foreground">
+                            Linked spool not found in Spoolman{' '}
+                            <Badge variant="outline" className="text-red-600 border-red-300">Missing</Badge>
+                          </span>
+                        )}
+                      </div>
+                    </div>
+
+                    {/* Actions */}
+                    <div className="flex items-center gap-2 flex-shrink-0">
+                      <Dialog open={editDialogOpen && editingMapping?.id === mapping.id} onOpenChange={(open) => {
+                        setEditDialogOpen(open);
+                        if (!open) setEditingMapping(null);
+                      }}>
+                        <DialogTrigger asChild>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => {
+                              setEditingMapping(mapping);
+                              setEditDialogOpen(true);
+                            }}
+                          >
+                            Change Spool
+                          </Button>
+                        </DialogTrigger>
+                        <DialogContent className="sm:max-w-lg">
+                          <DialogHeader>
+                            <DialogTitle>Change Spool for Mapping</DialogTitle>
+                            <DialogDescription>
+                              {mapping.material} &quot;{mapping.name}&quot; ({formatColor(mapping.color)})
+                            </DialogDescription>
+                          </DialogHeader>
+                          <Command className="border rounded-lg">
+                            <CommandInput placeholder="Search spools..." />
+                            <CommandList className="max-h-80">
+                              <CommandEmpty>No spools found.</CommandEmpty>
+                              <CommandGroup>
+                                {spools.map((spool) => (
+                                  <CommandItem
+                                    key={spool.id}
+                                    value={buildSpoolSearchValue(spool)}
+                                    onSelect={() => handleChangeSpool(mapping, spool.id)}
+                                  >
+                                    <div className="flex items-center gap-3 w-full">
+                                      <SpoolColorSwatch filament={spool.filament} size="h-6 w-6" />
+                                      <div className="flex-1 min-w-0">
+                                        <div className="flex items-center gap-2 flex-wrap">
+                                          <Badge variant="secondary" className="text-xs">{spool.filament.material}</Badge>
+                                          <span className="text-sm font-medium truncate">{spool.filament.name}</span>
+                                        </div>
+                                        {spool.filament.vendor?.name && (
+                                          <div className="text-xs text-muted-foreground truncate">
+                                            {spool.filament.vendor.name}
+                                          </div>
+                                        )}
+                                      </div>
+                                      <div className="text-xs text-muted-foreground whitespace-nowrap">
+                                        {spool.remaining_weight.toFixed(0)}g
+                                      </div>
+                                    </div>
+                                  </CommandItem>
+                                ))}
+                              </CommandGroup>
+                            </CommandList>
+                          </Command>
+                        </DialogContent>
+                      </Dialog>
+
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-destructive hover:text-destructive"
+                        onClick={() => handleDelete(mapping.id)}
+                      >
+                        Delete
+                      </Button>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+
+            <p className="text-xs text-muted-foreground text-center pt-2">
+              {mappings.length} mapping{mappings.length !== 1 ? 's' : ''}
+            </p>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -41,6 +41,7 @@ interface Settings {
   homeassistant: { url: string; connected: boolean } | null;
   spoolman: { url: string; connected: boolean } | null;
   showSpoolLocation?: boolean;
+  showPrinterFilamentReport?: boolean;
 }
 
 export default function Dashboard() {
@@ -220,20 +221,38 @@ export default function Dashboard() {
     };
   }, [settings?.homeassistant, settings?.spoolman, fetchData]);
 
-  const handleSpoolAssign = async (trayId: string, spoolId: number) => {
+  const handleSpoolAssign = async (trayId: string, spoolId: number, trayInfo?: { name?: string; material?: string; color?: string }) => {
     try {
       const res = await fetch('/api/spools', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ trayId, spoolId }),
+        body: JSON.stringify({
+          trayId,
+          spoolId,
+          ...(trayInfo?.name && { trayName: trayInfo.name }),
+          ...(trayInfo?.material && { trayMaterial: trayInfo.material }),
+          ...(trayInfo?.color && { trayColor: trayInfo.color }),
+        }),
       });
 
       if (!res.ok) {
         throw new Error('Failed to assign spool');
       }
 
+      const data = await res.json();
       toast.success('Spool assigned successfully');
-      fetchData(); // Refresh data
+      if (data.mappingCreated && data.spool?.filament) {
+        const f = (data.spool as Spool).filament;
+        const parts = [f.name, f.material, f.vendor?.name].filter(
+          (p): p is string => typeof p === 'string' && p.trim() !== '',
+        );
+        toast.info(
+          parts.length > 0
+            ? `Auto-mapping created for ${parts.join(' / ')}`
+            : `Auto-mapping created for spool #${spoolId}`,
+        );
+      }
+      fetchData();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to assign spool');
     }
@@ -476,6 +495,7 @@ export default function Dashboard() {
                 onSpoolAssign={handleSpoolAssign}
                 onSpoolUnassign={handleSpoolUnassign}
                 showSpoolLocation={settings?.showSpoolLocation}
+                showPrinterFilamentReport={settings?.showPrinterFilamentReport}
               />
             ))}
           </div>

--- a/app/src/app/settings/page.tsx
+++ b/app/src/app/settings/page.tsx
@@ -80,6 +80,8 @@ function SettingsContent() {
 
   // Dashboard display settings
   const [showSpoolLocation, setShowSpoolLocation] = useState(false);
+  const [showPrinterFilamentReport, setShowPrinterFilamentReport] = useState(false);
+  const [autoMappingEnabled, setAutoMappingEnabled] = useState(true);
 
   // QR base URL state
   const [qrBaseUrl, setQrBaseUrl] = useState('');
@@ -163,6 +165,12 @@ function SettingsContent() {
       }
       if (data.showSpoolLocation !== undefined) {
         setShowSpoolLocation(data.showSpoolLocation);
+      }
+      if (data.showPrinterFilamentReport !== undefined) {
+        setShowPrinterFilamentReport(data.showPrinterFilamentReport);
+      }
+      if (data.autoMappingEnabled !== undefined) {
+        setAutoMappingEnabled(data.autoMappingEnabled);
       }
     } catch {
       toast.error('Failed to load settings');
@@ -855,6 +863,70 @@ function SettingsContent() {
                       </Label>
                       <p className="text-xs text-muted-foreground">
                         Display the Spoolman location field on each spool card (e.g., shelf, dry box, bin number)
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center space-x-3 mt-4">
+                    <Checkbox
+                      id="show-printer-filament-report"
+                      checked={showPrinterFilamentReport}
+                      onCheckedChange={async (checked) => {
+                        const enabled = checked === true;
+                        setShowPrinterFilamentReport(enabled);
+                        try {
+                          const res = await fetch('/api/settings', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ type: 'show_printer_filament_report', enabled }),
+                          });
+                          if (!res.ok) throw new Error();
+                          toast.success(
+                            enabled
+                              ? 'Printer-reported filament shown on dashboard'
+                              : 'Printer-reported filament hidden on dashboard',
+                          );
+                        } catch {
+                          setShowPrinterFilamentReport(!enabled);
+                          toast.error('Failed to save setting');
+                        }
+                      }}
+                    />
+                    <div>
+                      <Label htmlFor="show-printer-filament-report" className="text-sm font-medium cursor-pointer">
+                        Show printer-reported name, type, and color
+                      </Label>
+                      <p className="text-xs text-muted-foreground">
+                        On each tray card, show the filament name, material type, and color as reported by the printer (from Home Assistant), alongside Spoolman data
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center space-x-3 mt-4">
+                    <Checkbox
+                      id="auto-mapping"
+                      checked={autoMappingEnabled}
+                      onCheckedChange={async (checked) => {
+                        const enabled = checked === true;
+                        setAutoMappingEnabled(enabled);
+                        try {
+                          const res = await fetch('/api/settings', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ type: 'auto_mapping', enabled }),
+                          });
+                          if (!res.ok) throw new Error();
+                          toast.success(enabled ? 'Auto filament mapping enabled' : 'Auto filament mapping disabled');
+                        } catch {
+                          setAutoMappingEnabled(!enabled);
+                          toast.error('Failed to save setting');
+                        }
+                      }}
+                    />
+                    <div>
+                      <Label htmlFor="auto-mapping" className="text-sm font-medium cursor-pointer">
+                        Auto-create filament mappings
+                      </Label>
+                      <p className="text-xs text-muted-foreground">
+                        When you manually assign a spool to a tray that has no RFID tag, automatically remember this name/material/color combination for future auto-assignment
                       </p>
                     </div>
                   </div>

--- a/app/src/components/dashboard/printer-card.tsx
+++ b/app/src/components/dashboard/printer-card.tsx
@@ -40,12 +40,13 @@ interface PrinterWithSpools {
 interface PrinterCardProps {
   printer: PrinterWithSpools;
   spools: Spool[];
-  onSpoolAssign: (trayId: string, spoolId: number) => void;
+  onSpoolAssign: (trayId: string, spoolId: number, trayInfo?: { name?: string; material?: string; color?: string }) => void;
   onSpoolUnassign: (spoolId: number) => void;
   showSpoolLocation?: boolean;
+  showPrinterFilamentReport?: boolean;
 }
 
-export function PrinterCard({ printer, spools, onSpoolAssign, onSpoolUnassign, showSpoolLocation }: PrinterCardProps) {
+export function PrinterCard({ printer, spools, onSpoolAssign, onSpoolUnassign, showSpoolLocation, showPrinterFilamentReport }: PrinterCardProps) {
   return (
     <Card className="w-full">
       <CardHeader className="pb-3">
@@ -67,10 +68,11 @@ export function PrinterCard({ printer, spools, onSpoolAssign, onSpoolUnassign, s
                   tray={tray}
                   assignedSpool={tray.assigned_spool}
                   spools={spools}
-                  onAssign={(spoolId) => onSpoolAssign(tray.unique_id || tray.entity_id, spoolId)}
+                  onAssign={(spoolId) => onSpoolAssign(tray.unique_id || tray.entity_id, spoolId, { name: tray.name, material: tray.material, color: tray.color })}
                   onUnassign={onSpoolUnassign}
                   mismatch={tray.mismatch}
                   showLocation={showSpoolLocation}
+                  showPrinterReport={showPrinterFilamentReport}
                 />
               ))}
             </div>
@@ -91,10 +93,11 @@ export function PrinterCard({ printer, spools, onSpoolAssign, onSpoolUnassign, s
                   assignedSpool={extSpool.assigned_spool}
                   spools={spools}
                   onAssign={(spoolId) => {
-                    onSpoolAssign(extSpool.unique_id || extSpool.entity_id, spoolId);
+                    onSpoolAssign(extSpool.unique_id || extSpool.entity_id, spoolId, { name: extSpool.name, material: extSpool.material, color: extSpool.color });
                   }}
                   onUnassign={onSpoolUnassign}
                   showLocation={showSpoolLocation}
+                  showPrinterReport={showPrinterFilamentReport}
                 />
               ))}
             </div>

--- a/app/src/components/dashboard/tray-slot.tsx
+++ b/app/src/components/dashboard/tray-slot.tsx
@@ -62,6 +62,19 @@ interface TraySlotProps {
   onUnassign?: (spoolId: number) => void;
   mismatch?: MismatchInfo;
   showLocation?: boolean;
+  /** Show name / material / color as reported by the printer (Home Assistant) */
+  showPrinterReport?: boolean;
+}
+
+function printerReportColorCss(color?: string): string | undefined {
+  if (!color?.trim()) return undefined;
+  const c = color.trim();
+  return c.startsWith('#') ? c : `#${c}`;
+}
+
+/** True when HA reports the literal empty slot (no filament loaded). */
+function isEmptyTraySentinelLabel(s: string | undefined): boolean {
+  return (s ?? '').trim().toLowerCase() === 'empty';
 }
 
 /**
@@ -102,7 +115,7 @@ function sortSpools(spools: Spool[], sortBy: SortBy): Spool[] {
   });
 }
 
-export function TraySlot({ tray, assignedSpool, spools, onAssign, onUnassign, mismatch, showLocation }: TraySlotProps) {
+export function TraySlot({ tray, assignedSpool, spools, onAssign, onUnassign, mismatch, showLocation, showPrinterReport }: TraySlotProps) {
   const [open, setOpen] = useState(false);
   const [filters, setFilters] = useState<Record<string, string | null>>({});
   const [enabledFields, setEnabledFields] = useState<FilterField[]>([]);
@@ -176,6 +189,53 @@ export function TraySlot({ tray, assignedSpool, spools, onAssign, onUnassign, mi
 
   const trayLabel = tray.is_external ? 'External' : `Tray ${tray.tray_number}`;
 
+  const printerReportsEmptySlot =
+    isEmptyTraySentinelLabel(tray.name) || isEmptyTraySentinelLabel(tray.material);
+
+  const showNameRow = Boolean(tray.name?.trim()) && !isEmptyTraySentinelLabel(tray.name);
+  const showTypeRow = Boolean(tray.material?.trim()) && !isEmptyTraySentinelLabel(tray.material);
+  const showColorRow = Boolean(tray.color?.trim());
+
+  const hasPrinterReportData =
+    !printerReportsEmptySlot && (showNameRow || showTypeRow || showColorRow);
+
+  const printerReportBlock =
+    showPrinterReport && hasPrinterReportData ? (
+      <div className="rounded-md bg-muted/40 border border-border/60 px-2 py-1.5 space-y-1 w-full">
+        <div className="text-[8px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Printer-reported info
+        </div>
+        {showNameRow && (
+          <div className="flex gap-1.5 text-[10px] leading-tight">
+            <span className="text-muted-foreground shrink-0 w-14">Name</span>
+            <span className="font-medium truncate min-w-0" title={tray.name}>
+              {tray.name}
+            </span>
+          </div>
+        )}
+        {showTypeRow && (
+          <div className="flex gap-1.5 text-[10px] leading-tight">
+            <span className="text-muted-foreground shrink-0 w-14">Type</span>
+            <span className="font-medium truncate min-w-0" title={tray.material}>
+              {tray.material}
+            </span>
+          </div>
+        )}
+        {showColorRow && (
+          <div className="flex gap-1.5 text-[10px] leading-tight items-center min-w-0">
+            <span className="text-muted-foreground shrink-0 w-14">Color</span>
+            <span
+              className="h-3.5 w-3.5 rounded-full border border-border shrink-0"
+              style={{ backgroundColor: printerReportColorCss(tray.color) }}
+            />
+            <span className="font-mono text-[9px] truncate min-w-0" title={tray.color}>
+              {tray.color}
+            </span>
+          </div>
+        )}
+      </div>
+    ) : null;
+
   // Check if any enabled filters have values to show
   const hasFilterOptions = enabledFields.some(f => f.values.length > 0);
 
@@ -242,6 +302,8 @@ export function TraySlot({ tray, assignedSpool, spools, onAssign, onUnassign, mi
                 )}
               </div>
 
+              {printerReportBlock && <div className="w-full mt-1">{printerReportBlock}</div>}
+
               {/* Footer: spool ID and weight */}
               <div className="flex items-center justify-between mt-auto pt-1">
                 <span className="text-[10px] text-muted-foreground">
@@ -256,7 +318,8 @@ export function TraySlot({ tray, assignedSpool, spools, onAssign, onUnassign, mi
             </>
           ) : (
             /* Empty tray state */
-            <div className="flex flex-col items-center justify-center flex-1 py-2">
+            <div className="flex flex-col items-center justify-center flex-1 py-2 w-full">
+              {printerReportBlock && <div className="w-full mb-2">{printerReportBlock}</div>}
               <div
                 className="h-8 w-8 rounded-full border-2 border-dashed border-muted-foreground/30 mb-2"
               />

--- a/app/src/components/nav.tsx
+++ b/app/src/components/nav.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button';
 const navItems = [
   { href: '/', label: 'Dashboard' },
   { href: '/scan', label: 'Scan' },
+  { href: '/mappings', label: 'Mappings' },
   { href: '/reports', label: 'Reports' },
   { href: '/automations', label: 'Automations' },
   { href: '/settings', label: 'Settings' },

--- a/app/src/lib/ha-config-generator.ts
+++ b/app/src/lib/ha-config-generator.ts
@@ -391,7 +391,7 @@ function generateAutomationsYaml(
 # SpoolmanSync Automation: Tray Change Detection
 #
 # Detects physical spool changes (insert/remove) and syncs with Spoolman.
-# Triggers when any AMS tray or external spool sensor changes state.
+# Fires on any tray sensor state update; SpoolmanSync webhook decides what to do.
 # =============================================================================
 - id: 'spoolmansync_tray_change_${prefix}'
   alias: SpoolmanSync - Tray Change (${prefix})
@@ -401,16 +401,6 @@ function generateAutomationsYaml(
     - entity_id:
 ${trayEntityIds.map(id => `        - ${id}`).join('\n')}
       trigger: state
-  conditions:
-    # Only trigger if the entity is actually available
-    - condition: template
-      value_template: "{{ trigger.to_state is not none and trigger.to_state.state not in ['unavailable', 'unknown'] }}"
-    # Debounce: only trigger if tray_uuid or name actually changed between old and new state
-    - condition: template
-      value_template: >-
-        {{ trigger.from_state is none or trigger.to_state is none or
-           trigger.to_state.attributes.get('tray_uuid', '') != trigger.from_state.attributes.get('tray_uuid', '') or
-           trigger.to_state.attributes.get('name', '') != trigger.from_state.attributes.get('name', '') }}
   variables:
     tray_entity_id: "{{ trigger.entity_id }}"
     tray_uuid: "{{ state_attr(trigger.entity_id, 'tray_uuid') | default('') }}"
@@ -620,7 +610,7 @@ function generateCrealityAutomationsYaml(
 # SpoolmanSync Automation: Tray Change Detection (Creality)
 #
 # Detects physical spool changes (insert/remove) in CFS slots.
-# Triggers when any CFS slot sensor changes state.
+# Fires on any slot sensor state update; SpoolmanSync webhook decides what to do.
 # =============================================================================
 - id: 'spoolmansync_tray_change_${prefix}'
   alias: SpoolmanSync - Tray Change (${prefix})
@@ -629,15 +619,6 @@ function generateCrealityAutomationsYaml(
     - entity_id:
 ${trayEntityIds.map(id => `        - ${id}`).join('\n')}
       trigger: state
-  conditions:
-    - condition: template
-      value_template: "{{ trigger.to_state is not none and trigger.to_state.state not in ['unavailable', 'unknown'] }}"
-    # Debounce: only trigger if rfid or name actually changed
-    - condition: template
-      value_template: >-
-        {{ trigger.from_state is none or trigger.to_state is none or
-           trigger.to_state.attributes.get('rfid', '') != trigger.from_state.attributes.get('rfid', '') or
-           trigger.to_state.attributes.get('name', '') != trigger.from_state.attributes.get('name', '') }}
   variables:
     tray_entity_id: "{{ trigger.entity_id }}"
     tray_uuid: "{{ state_attr(trigger.entity_id, 'rfid') | default('') }}"


### PR DESCRIPTION
# Filament Mapping: auto-assign spools by name/material/color

## Problem

When using non-Bambu filament (or any spool without RFID tags / QR codes), every tray change on the printer triggers a `tray_change` webhook that reaches the "no match" branch. The user is then forced to open the SpoolmanSync dashboard and manually assign the correct spool to the tray — even though the printer already reports the filament's **name**, **material**, and **color** via Home Assistant.

This creates unnecessary friction: you set the filament type on the printer's display (or in Bambu Studio), but still have to repeat the assignment in SpoolmanSync every single time.

## Solution

Introduce a **Filament Mapping** system that remembers associations between printer-reported filament attributes (`name + material + color`) and Spoolman spool IDs. Once a mapping exists, future tray changes with the same combination are auto-assigned — no manual intervention required.

### How it works

1. **Auto-creation of mappings**: When a user manually assigns a spool to a tray via the dashboard, and that spool has no RFID/serial tag, the system automatically creates (or updates) a mapping for the tray's current `name + material + color` → that spool. A toast notification informs the user.

2. **Webhook lookup chain** (`tray_change` event):
   - First: try matching by spool serial / UUID (existing RFID-based flow — unchanged)
   - **New**: if no UUID match, look up the `FilamentMapping` table by normalized `name + material + color`
   - If a mapping is found and the spool is not archived, auto-assign it
   - Last resort: fall through to "no match" (see **Stale assignments** below)

3. **Mappings management page** (`/mappings`): A new page between Scan and Reports in the navigation. Shows all stored mappings with color swatches, material badges, and the linked spool (human-readable filament line, no internal IDs in the UI).

4. **Settings toggles**:
   - **Auto-create filament mappings** — controls whether mappings are created automatically on manual assignment. Enabled by default.
   - **Show printer-reported name, type, and color** (Dashboard Display) — optional block on each tray card titled **Printer-reported info** with name, material type, and color as reported by Home Assistant. **Off by default.**

### Stale assignments when the printer report changes

If the user changes filament (e.g. color) on the printer and **no** RFID match, **no** filament mapping, or only an archived/missing mapped spool applies, the webhook previously left the old Spoolman assignment in place. **Now**, in that **no match** path, any spool still assigned to that tray is **automatically unassigned**, so the dashboard reflects an unknown filament state instead of a wrong spool. An activity log entry records the unassign with reason `tray_change_no_match`.

### UX refinements

- **Toast on auto-mapping**: After a successful manual assign that creates a mapping, the toast uses the assigned spool's **filament name / material / vendor** from Spoolman (not raw tray color hex).
- **Printer-reported info** on the dashboard: Shown only when the setting is enabled **and** the printer does not report an empty slot for name or type (`Empty` is case-insensitive). The card is omitted entirely in that case.

### Changes (summary)

- **Database**: `FilamentMapping` model with unique constraint on `(name, material, color)`
- **API**: `/api/mappings` (GET, POST, DELETE); `POST /api/spools` extended with optional tray fields and mapping auto-create
- **Webhook** (`/api/webhook`): Filament mapping lookup; **no match** clears prior tray assignment when applicable
- **Settings**: `auto_mapping_enabled`, `show_printer_filament_report`
- **Frontend**: `/mappings` page, navigation, dashboard tray info for assign, optional printer-reported block on tray cards
