### PR TITLE
Fix: ignore unavailable/unknown flickers in tray trigger (mid-print meter reset)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to SpoolmanSync will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Filament usage was massively under-counted when the printer/MQTT connection briefly flickered mid-print. A transient `unavailable` blip on the active-tray sensor was misread as a tray change by the "Update Spool" automation, resetting the usage utility meter and discarding all filament tracked so far. Only filament used after the blip was deducted at print end (e.g. 2.3g logged for a 25.6g print). The tray trigger now ignores `unavailable`/`unknown` transitions (Bambu and Creality).
+
 ## [1.5.3] - 2026-04-19
 
 ### Fixed

--- a/app/src/lib/ha-config-generator.ts
+++ b/app/src/lib/ha-config-generator.ts
@@ -230,6 +230,15 @@ function generateAutomationsYaml(
   triggers:
     - entity_id: sensor.spoolmansync_${prefix}_active_tray
       id: tray
+      # Ignore transient availability flickers (e.g. MQTT reconnects). A blip to
+      # 'unavailable' and back is not a real tray change, and must not trigger the
+      # meter reset below — otherwise mid-print usage already on the meter is lost.
+      not_from:
+        - unavailable
+        - unknown
+      not_to:
+        - unavailable
+        - unknown
       trigger: state
     - entity_id: ${entities.current_stage}
       to:
@@ -473,6 +482,15 @@ function generateCrealityAutomationsYaml(
   triggers:
     - entity_id: sensor.spoolmansync_${prefix}_active_tray
       id: tray
+      # Ignore transient availability flickers (e.g. MQTT reconnects). A blip to
+      # 'unavailable' and back is not a real tray change, and must not trigger the
+      # meter reset below — otherwise mid-print usage already on the meter is lost.
+      not_from:
+        - unavailable
+        - unknown
+      not_to:
+        - unavailable
+        - unknown
       trigger: state
     - entity_id: ${entities.current_stage}
       to:


### PR DESCRIPTION
## Problem

Filament usage can be massively under-counted if the printer/MQTT connection briefly flickers during a print.

The **Update Spool** automation triggers on any state change of `sensor.spoolmansync_<prefix>_active_tray`:

```yaml
triggers:
  - entity_id: sensor.spoolmansync_<prefix>_active_tray
    id: tray
    trigger: state
```

That sensor’s availability is `false` when all of a printer's tray sensors are unavailable. So a momentary integration/MQTT hiccup makes `active_tray` go `N -> unavailable -> N` and both edges trigger the automation:

- On the `unavailable -> N` edge, `old_tray` resolves to `-1`, so the tray-change branch falls through to its **default**, which unconditionally resets the usage meter:

  ```yaml
  # Reset meter anyway to prevent stale values from accumulating
  - action: utility_meter.calibrate
    target: { entity_id: sensor.spoolmansync_<prefix>_filament_usage_meter }
    data: { value: "0" }
  ```

All filament tracked before the blip is discarded. The meter recounts from 0, and the print-end deduction only reflects usage *after* the flicker.

### Real-world example

A 25.58g print flickered once at ~90% progress. The meter (correctly at ~23g) was reset to 0, then only re-accumulated the final ~10%. Spoolman was charged `2.3g` for a `25.6g` print.

The `Tray Change` automation already guards against this exact case (`trigger.to_state.state not in ['unavailable', 'unknown']`); the `Update Spool` automation's tray trigger does not.

## Fix

Add `not_from`/`not_to` guards to the tray trigger so transient `unavailable`/`unknown` transitions don't run the automation. Applied to both the Bambu and Creality generators.

```yaml
triggers:
  - entity_id: sensor.spoolmansync_<prefix>_active_tray
    id: tray
    not_from: [unavailable, unknown]
    not_to:   [unavailable, unknown]
    trigger: state
```

Genuine tray changes (including a real tray -> "no active tray"/empty-string transition) still trigger as before.

## Notes

- Users must regenerate their HA config (re-run config generation in the add-on) to pick up the new trigger.
