### PR TITLE
Preserve tray assignment during AMS runout auto-switch

### DIFF
--- a/app/src/app/api/webhook/route.ts
+++ b/app/src/app/api/webhook/route.ts
@@ -6,7 +6,7 @@ import { spoolEvents, SPOOL_UPDATED, SpoolUpdateEvent } from '@/lib/events';
 import { createActivityLog } from '@/lib/activity-log';
 import { checkAndUpdateAlerts } from '@/lib/alerts';
 import { getWebhookSecret, isWebhookAuthEnabled, tokensMatch, WEBHOOK_TOKEN_HEADER } from '@/lib/webhook-secret';
-import { isValidTrayUuid, lengthToWeight, classifyTrayState } from '@/lib/webhook-helpers';
+import { isValidTrayUuid, lengthToWeight, classifyTrayState, isActivePrintState } from '@/lib/webhook-helpers';
 
 /**
  * Webhook endpoint for Home Assistant automations
@@ -216,7 +216,7 @@ export async function POST(request: NextRequest) {
 
     // Handle tray_change event - auto-assign spool by serial number or handle empty tray
     if (event === 'tray_change') {
-      const { tray_entity_id, tray_uuid, name, material } = body;
+      const { tray_entity_id, tray_uuid, name, material, current_print_state } = body;
       const spools = await client.getSpools();
 
       // Resolve entity_id to unique_id for matching and assignment
@@ -244,6 +244,20 @@ export async function POST(request: NextRequest) {
             details: { trayId: tray_entity_id, reason: 'auto_clear_disabled' },
           });
           return NextResponse.json({ status: 'ignored', reason: 'auto_clear_disabled' });
+        }
+
+        // During an active print, an empty tray can be a real AMS runout event.
+        // Preserve the assignment so the Update Spool automation can flush the
+        // old active tray's accumulated usage against the ran-out spool before
+        // any cleanup happens. Otherwise an auto-unassign here makes the
+        // subsequent spool_usage webhook unable to find the old spool.
+        if (isActivePrintState(current_print_state)) {
+          await createActivityLog({
+            type: 'tray_change_ignored',
+            message: `Detected empty tray ${tray_entity_id} while printer is ${current_print_state} — assignment preserved for usage accounting`,
+            details: { trayId: tray_entity_id, reason: 'active_print_empty_tray', currentPrintState: current_print_state },
+          });
+          return NextResponse.json({ status: 'ignored', reason: 'active_print_empty_tray' });
         }
 
         // Defense-in-depth: re-query the live HA state before unassigning. A 4-5s
@@ -437,6 +451,7 @@ export async function GET() {
           tray_uuid: '...',
           color: '#FFFFFF',
           material: 'PLA',
+          current_print_state: 'printing',
         },
       },
     },

--- a/app/src/lib/ha-config-generator.test.ts
+++ b/app/src/lib/ha-config-generator.test.ts
@@ -130,6 +130,18 @@ describe('generateHAConfig — output is well-formed YAML', () => {
     }
   });
 
+  it('tray trigger passes the current print state to the tray-change webhook', () => {
+    for (const printer of [bambuPrinter(), crealityPrinter()]) {
+      const { automationsYaml, configurationAdditions } = generateHAConfig([printer], 'http://hook', 'http://hook');
+      const parsed = parseYaml(automationsYaml);
+      const trayChange = parsed.find((a: { id: string }) => a.id === `spoolmansync_tray_change_${printer.prefix}`);
+      const restAction = trayChange.actions.find((a: { action?: string }) => a.action === 'rest_command.spoolmansync_tray_change');
+
+      expect(restAction.data.current_print_state).toContain('states(');
+      expect(configurationAdditions).toContain('"current_print_state": "{{ current_print_state }}"');
+    }
+  });
+
   it('returns empty config for no printers', () => {
     const cfg = generateHAConfig([], 'http://hook', 'http://hook');
     expect(cfg.automationsYaml).toBe('[]');

--- a/app/src/lib/ha-config-generator.ts
+++ b/app/src/lib/ha-config-generator.ts
@@ -465,6 +465,7 @@ ${trayEntityIds.map(id => `        - ${id}`).join('\n')}
         name: "{{ name }}"
         material: "{{ material }}"
         color: "{{ color }}"
+        current_print_state: "{{ states('${entities.current_stage}') }}"
   mode: queued
   max: 10
 `;
@@ -725,6 +726,7 @@ ${trayEntityIds.map(id => `        - ${id}`).join('\n')}
         name: "{{ name }}"
         material: "{{ material }}"
         color: "{{ color }}"
+        current_print_state: "{{ states('${entities.current_stage}') }}"
   mode: queued
   max: 10
 `;
@@ -907,7 +909,8 @@ rest_command:
         "tray_uuid": "{{ tray_uuid }}",
         "name": "{{ name }}",
         "material": "{{ material }}",
-        "color": "{{ color }}"
+        "color": "{{ color }}",
+        "current_print_state": "{{ current_print_state }}"
       }
 
 # Template sensors for filament tracking

--- a/app/src/lib/webhook-helpers.test.ts
+++ b/app/src/lib/webhook-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { classifyTrayState, lengthToWeight, isValidTrayUuid, MATERIAL_DENSITY } from './webhook-helpers';
+import { classifyTrayState, lengthToWeight, isValidTrayUuid, isActivePrintState, MATERIAL_DENSITY } from './webhook-helpers';
 
 describe('classifyTrayState (issue #65 — never clear on transient states)', () => {
   it('treats unavailable/unknown/missing as transient (must NOT clear assignment)', () => {
@@ -60,5 +60,19 @@ describe('isValidTrayUuid', () => {
   it('accepts a real serial', () => {
     expect(isValidTrayUuid('A1B2C3D4')).toBe(true);
     expect(isValidTrayUuid('0000A0000')).toBe(true); // not all zeros
+  });
+});
+
+describe('isActivePrintState', () => {
+  it('treats terminal/unknown states as inactive', () => {
+    for (const state of [undefined, null, '', 'idle', 'finished', 'completed', 'complete', 'offline', 'off', 'none', 'unknown', 'unavailable']) {
+      expect(isActivePrintState(state)).toBe(false);
+    }
+  });
+
+  it('treats printing/pausing style states as active', () => {
+    for (const state of ['printing', 'running', 'paused', 'pause', 'prepare', 'slicing', 'auto_bed_leveling']) {
+      expect(isActivePrintState(state)).toBe(true);
+    }
   });
 });

--- a/app/src/lib/webhook-helpers.ts
+++ b/app/src/lib/webhook-helpers.ts
@@ -63,3 +63,19 @@ export function classifyTrayState(name: string | null | undefined): 'transient' 
   }
   return 'present';
 }
+
+/**
+ * Returns true when the printer stage/status represents an active or pausing
+ * print. Empty-tray events during these states can be Bambu AMS runout / auto-
+ * refill transitions; clearing the old tray assignment immediately can make the
+ * subsequent usage flush unable to find the ran-out spool.
+ */
+export function isActivePrintState(state: string | null | undefined): boolean {
+  const normalized = (state ?? '').toString().trim().toLowerCase();
+
+  if (!normalized || ['idle', 'finished', 'completed', 'complete', 'offline', 'off', 'none', 'unknown', 'unavailable'].includes(normalized)) {
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Summary

Fixes a Bambu AMS runout / auto-refill edge case where the old tray can report `Empty` while the printer is still actively printing. Previously the tray-change webhook could auto-unassign the ran-out spool before the Update Spool automation flushed the accumulated usage for the old active tray, so the ran-out spool was not deducted and only the replacement spool saw usage.

This PR:

- includes the current printer stage/status in generated tray-change webhook payloads
- treats empty-tray events during active print states as runout/auto-refill candidates
- preserves the old tray assignment during active prints so the subsequent usage webhook can still match and deduct the ran-out spool
- keeps existing empty-tray auto-clear behavior when the printer is idle/finished/offline
- adds tests for active-print state classification and generated webhook payloads

## Tests

- `DATABASE_URL='file:./dev.db' npx prisma generate`
- `npm test`
- `npx vitest run src/lib/webhook-helpers.test.ts src/lib/ha-config-generator.test.ts`
- `npx eslint src/lib/webhook-helpers.ts src/lib/webhook-helpers.test.ts src/lib/ha-config-generator.ts src/lib/ha-config-generator.test.ts src/app/api/webhook/route.ts`
- `npm run build`
- `git diff --check`

Note: full `npm run lint` still fails on pre-existing unrelated lint issues in the repo (settings route, kiosk/theme/effect patterns, QR scanner, etc.); changed files pass eslint directly.

## Upgrade note

Existing users need to re-run Auto-configure / regenerate Home Assistant automations so tray-change webhooks include `current_print_state`.
